### PR TITLE
Skip mismatched log lines instead of stopping the parsing

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -262,6 +262,14 @@ xx.xx.xx.xx [2024-07-24T00:00:51+00:00] jorge.olano.dev /var/www/jorge jorge.ola
 	assertEqual(t, rows[0][0], "jorge.olano.dev")
 }
 
+func TestMismatchedLine(t *testing.T) {
+	sample := `xx.xx.xx.xx - - [24/Jul/2024:00:00:28 +0000] "GET /feed HTTP/1.1" 301 169 "-" "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/109.0.0.0 Safari/537.36"
+this has a different format
+xx.xx.xx.xx - - [24/Jul/2024:00:00:30 +0000] "GET /feed HTTP/1.1" 301 169 "-" "feedi/0.1.0 (+https://github.com/facundoolano/feedi)"`
+	_, rows := runCommand(t, DEFAULT_LOG_FORMAT, sample, []string{})
+	assertEqual(t, rows[0][0], "2")
+}
+
 func TestMultipleLogFiles(t *testing.T) {
 	// TODO implement test
 	// more than one file in a dir, honoring the glob pattern

--- a/ngtop/parser.go
+++ b/ngtop/parser.go
@@ -90,7 +90,9 @@ func (parser LogParser) Parse(
 			line := scanner.Text()
 			values, err := parseLogLine(parser.formatRegex, line)
 			if err != nil {
-				return err
+				// don't break on parsing error, just skip the line
+				log.Println(err)
+				continue
 			}
 			if values == nil {
 				log.Printf("couldn't parse line %s", line)


### PR DESCRIPTION
fixes #18