### PR TITLE
Fix parse until last seen bug

### DIFF
--- a/ngtop/db.go
+++ b/ngtop/db.go
@@ -74,7 +74,9 @@ func (dbs *DBSession) PrepareForUpdate() (*time.Time, error) {
 	var lastSeemTime *time.Time
 	// this query error is acceptable in case of db not exists or empty
 	if err := dbs.db.QueryRow("SELECT max(time) FROM access_logs").Scan(&lastSeenTimeStr); err == nil {
-		_, err := dbs.db.Exec("DELETE FROM access_logs WHERE time = ?", lastSeenTimeStr)
+		query := "DELETE FROM access_logs WHERE time = ?"
+		log.Printf("query: %s %s\n", query, lastSeenTimeStr)
+		_, err := dbs.db.Exec(query, lastSeenTimeStr)
 		if err != nil {
 			return nil, err
 		}

--- a/ngtop/parser.go
+++ b/ngtop/parser.go
@@ -70,7 +70,7 @@ func (parser LogParser) Parse(
 
 	for _, path := range logFiles {
 
-		log.Printf("parsing %s", path)
+		log.Printf("parsing %s until %s", path, until)
 		file, err := os.Open(path)
 		if err != nil {
 			return err
@@ -101,6 +101,7 @@ func (parser LogParser) Parse(
 
 			if untilStr != "" && values["time"] < untilStr {
 				// already caught up, no need to continue processing
+				log.Printf("stopped parsing at %s", values["time"])
 				return nil
 			}
 


### PR DESCRIPTION
This updates the log file scanning by reading the file until the end and optionally skip older files when already seen entries are found. This approach may do some unnecessary reading/parsing (as opposed to scanning from the end of the file) but it's simpler and allows to remove the messy logic of truncating the db to avoid duplicates (which likely had a bug as well).

fixes #20