### PR TITLE
Fix parse until more

### DIFF
--- a/ngtop/db.go
+++ b/ngtop/db.go
@@ -64,10 +64,23 @@ func (dbs *DBSession) Close() {
 
 // Prepare a transaction to insert a new batch of log entries, returning the time of the last seen log entry.
 func (dbs *DBSession) PrepareForUpdate() (*time.Time, error) {
+	// we want to avoid processed files that were already processed in the past.  but we still want to add new log entries
+	// from the most recent files, which may have been extended since we last saw them.
+	// Since there is no "uniqueness" in logs (even the same ip can make the same request at the same second ---I checked),
+	// I remove the entries with the highest timestamp, and load everything up until including that timestamp but not older.
+	// The assumption is that any processing was completely finished, not interrupted.
+
 	var lastSeenTimeStr string
 	var lastSeemTime *time.Time
 	// this query error is acceptable in case of db not exists or empty
 	if err := dbs.db.QueryRow("SELECT max(time) FROM access_logs").Scan(&lastSeenTimeStr); err == nil {
+		query := "DELETE FROM access_logs WHERE time = ?"
+		_, err := dbs.db.Exec(query, lastSeenTimeStr)
+		log.Printf("query: %s %s\n", query, lastSeenTimeStr)
+		if err != nil {
+			return nil, err
+		}
+
 		t, _ := time.Parse(DB_DATE_LAYOUT, lastSeenTimeStr)
 		lastSeemTime = &t
 	}

--- a/ngtop/parser.go
+++ b/ngtop/parser.go
@@ -101,8 +101,8 @@ func (parser LogParser) Parse(
 			}
 
 			if untilStr != "" && values["time"] < untilStr {
-				// if this file contains entries older than the untilStr, it means we already parsed part of it before
-				// since the files contains oldest entries at the beginning, we need to keep parsing until the end to get
+				// If this file contains entries older than the untilStr, it means we already parsed part of it before.
+				// Since the files contains oldest entries at the beginning, we need to keep parsing until the end to get
 				// all the updates, but we flag it as already seen so we skip parsing newer ones
 				alreadySeenFile = true
 				continue


### PR DESCRIPTION
Turns out the delete I removed in #21 was still necessary. Without it the most recent log would be duplicated on each run.
Updated the testcase to capture that scenario.