### PR TITLE
Tweak cgo compilation to prevent linking errors

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,6 +35,8 @@ jobs:
       run: sudo apt-get -y install gcc-aarch64-linux-gnu
     - name: Build Binary
       run: CGO_ENABLED=1 CC=${{ matrix.cc }} GOOS=${{ matrix.goos }} GOARCH=${{ matrix.goarch }} go build -ldflags="-s -w" -o ${{ env.filename }} .
+
+    # if the same arch as the runner, try the binary to verify it runs properly
     - name: test binary
       if: matrix.goarch == 'amd64'
       run: chmod +x ${{ env.filename }} && ./${{ env.filename }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,6 +35,7 @@ jobs:
       run: sudo apt-get -y install gcc-aarch64-linux-gnu
     - name: Build Binary
       # see https://www.arp242.net/static-go.html
+      # an alternative is to switch to https://pkg.go.dev/modernc.org/sqlite (a pure go implementation) and remove cgo altogether
       run: CGO_ENABLED=1 CC=${{ matrix.cc }} GOOS=${{ matrix.goos }} GOARCH=${{ matrix.goarch }} go build -ldflags="-s -w -extldflags=-static" -tags sqlite_omit_load_extension,netgo,osusergo -o ${{ env.filename }} .
 
     # if the same arch as the runner, try the binary to verify it runs properly

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,8 @@ jobs:
     - name: install cross compiler
       run: sudo apt-get -y install gcc-aarch64-linux-gnu
     - name: Build Binary
-      run: CGO_ENABLED=1 CC=${{ matrix.cc }} GOOS=${{ matrix.goos }} GOARCH=${{ matrix.goarch }} go build -ldflags="-s -w -extldflags=-static" -tags sqlite_omit_load_extension -o ${{ env.filename }} .
+      # see https://www.arp242.net/static-go.html
+      run: CGO_ENABLED=1 CC=${{ matrix.cc }} GOOS=${{ matrix.goos }} GOARCH=${{ matrix.goarch }} go build -ldflags="-s -w -extldflags=-static -linkmode 'external'" -tags sqlite_omit_load_extension -o ${{ env.filename }} .
 
     # if the same arch as the runner, try the binary to verify it runs properly
     - name: test binary

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,8 @@ jobs:
             cc: gcc
           - goarch: arm64
             cc: aarch64-linux-gnu-gcc
+    env:
+      filename: ngtop-${{ matrix.goos }}-${{ matrix.goarch }}${{ matrix.ext }}
 
     steps:
     - name: Checkout code
@@ -32,9 +34,9 @@ jobs:
     - name: install cross compiler
       run: sudo apt-get -y install gcc-aarch64-linux-gnu
     - name: Build Binary
-      run: CGO_ENABLED=1 CC=${{ matrix.cc }} GOOS=${{ matrix.goos }} GOARCH=${{ matrix.goarch }} go build -ldflags="-s -w" -o ngtop-${{ matrix.goos }}-${{ matrix.goarch }}${{ matrix.ext }} .
+      run: CGO_ENABLED=1 CC=${{ matrix.cc }} GOOS=${{ matrix.goos }} GOARCH=${{ matrix.goarch }} go build -ldflags="-s -w" -o $filename .
 
     - name: Release
       uses: softprops/action-gh-release@v1
       with:
-        files: "ngtop-*"
+        files: $filename

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
       run: sudo apt-get -y install gcc-aarch64-linux-gnu
     - name: Build Binary
       # see https://www.arp242.net/static-go.html
-      run: CGO_ENABLED=1 CC=${{ matrix.cc }} GOOS=${{ matrix.goos }} GOARCH=${{ matrix.goarch }} go build -ldflags="-s -w -extldflags=-static -linkmode 'external'" -tags sqlite_omit_load_extension -o ${{ env.filename }} .
+      run: CGO_ENABLED=1 CC=${{ matrix.cc }} GOOS=${{ matrix.goos }} GOARCH=${{ matrix.goarch }} go build -ldflags="-s -w -extldflags=-static" -tags sqlite_omit_load_extension,netgo,osusergo -o ${{ env.filename }} .
 
     # if the same arch as the runner, try the binary to verify it runs properly
     - name: test binary

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
     - name: install cross compiler
       run: sudo apt-get -y install gcc-aarch64-linux-gnu
     - name: Build Binary
-      run: CGO_ENABLED=1 CC=${{ matrix.cc }} GOOS=${{ matrix.goos }} GOARCH=${{ matrix.goarch }} go build -ldflags="-s -w" -o ${{ env.filename }} .
+      run: CGO_ENABLED=1 CC=${{ matrix.cc }} GOOS=${{ matrix.goos }} GOARCH=${{ matrix.goarch }} go build -ldflags="-s -w -extldflags=-static" -tags sqlite_omit_load_extension -o ${{ env.filename }} .
 
     # if the same arch as the runner, try the binary to verify it runs properly
     - name: test binary

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,6 +36,7 @@ jobs:
     - name: Build Binary
       run: CGO_ENABLED=1 CC=${{ matrix.cc }} GOOS=${{ matrix.goos }} GOARCH=${{ matrix.goarch }} go build -ldflags="-s -w" -o ${{ env.filename }} .
     - name: test binary
+      if: matrix.goarch == 'amd64'
       run: chmod +x ${{ env.filename }} && ./${{ env.filename }}
 
     - name: Release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,9 +34,11 @@ jobs:
     - name: install cross compiler
       run: sudo apt-get -y install gcc-aarch64-linux-gnu
     - name: Build Binary
-      run: CGO_ENABLED=1 CC=${{ matrix.cc }} GOOS=${{ matrix.goos }} GOARCH=${{ matrix.goarch }} go build -ldflags="-s -w" -o $filename .
+      run: CGO_ENABLED=1 CC=${{ matrix.cc }} GOOS=${{ matrix.goos }} GOARCH=${{ matrix.goarch }} go build -ldflags="-s -w" -o ${{ env.filename }} .
+    - name: test binary
+      run: chmod +x ${{ env.filename }} && ./${{ env.filename }}
 
     - name: Release
       uses: softprops/action-gh-release@v1
       with:
-        files: $filename
+        files: ${{ env.filename }}


### PR DESCRIPTION
Tweaks ldflags to do static linking of glibc as per (based on this https://www.arp242.net/static-go.html).
An alternative worth considering is to just use a pure go sqlite driver and skip cgo altogether.

fixes #23