### PR TITLE
Add remote_user parsing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,9 @@ pull:
 run:
 	NGTOP_LOGS_PATH=./logs/access.log* go run .
 
+test:
+	go test ./...
+
 db:
 	sqlite3 -cmd ".open ngtop.db"
 

--- a/main_test.go
+++ b/main_test.go
@@ -100,8 +100,8 @@ const SAMPLE_LOGS = `xx.xx.xx.xx - - [24/Jul/2024:00:00:28 +0000] "GET /feed HTT
 xx.xx.xx.xx - - [24/Jul/2024:00:00:30 +0000] "GET /feed HTTP/1.1" 301 169 "-" "feedi/0.1.0 (+https://github.com/facundoolano/feedi)"
 xx.xx.xx.xx - - [24/Jul/2024:00:00:56 +0000] "GET /blog/deconstructing-the-role-playing-videogame/ HTTP/1.1" 200 14224 "-" "feedi/0.1.0 (+https://github.com/facundoolano/feedi)"
 xx.xx.xx.xx - - [24/Jul/2024:00:01:18 +0000] "GET /feed.xml HTTP/1.1" 200 9641 "https://olano.dev/feed.xml" "FreshRSS/1.24.0 (Linux; https://freshrss.org)"
-xx.xx.xx.xx - - [24/Jul/2024:00:01:20 +0000] "GET /feed.xml HTTP/1.1" 200 9641 "https://olano.dev/feed.xml" "FreshRSS/1.24.0 (Linux; https://freshrss.org)"
-xx.xx.xx.xx - - [24/Jul/2024:00:01:51 +0000] "GET /feed.xml HTTP/1.1" 200 9641 "https://olano.dev/feed.xml" "FreshRSS/1.24.0 (Linux; https://freshrss.org)"
+xx.xx.xx.xx - facundo [24/Jul/2024:00:01:20 +0000] "GET /feed.xml HTTP/1.1" 200 9641 "https://olano.dev/feed.xml" "FreshRSS/1.24.0 (Linux; https://freshrss.org)"
+xx.xx.xx.xx - facundo [24/Jul/2024:00:01:51 +0000] "GET /feed.xml HTTP/1.1" 200 9641 "https://olano.dev/feed.xml" "FreshRSS/1.24.0 (Linux; https://freshrss.org)"
 xx.xx.xx.xx - - [24/Jul/2024:00:02:17 +0000] "GET / HTTP/1.1" 200 1120 "https://olano.dev/" "SimplePie/1.8.0 (Feed Parser; http://simplepie.org; Allow like Gecko) Build/1674203855"
 xx.xx.xx.xx - - [24/Jul/2024:00:04:49 +0000] "GET /blog/mi-descubrimiento-de-america HTTP/1.1" 301 169 "-" "Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5X Build/MMB29P) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.6478.126 Mobile Safari/537.36 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)"
 xx.xx.xx.xx - - [24/Jul/2024:00:06:41 +0000] "GET /blog/a-few-more-things-you-can-do-on-your-website HTTP/1.1" 301 169 "-" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_2) AppleWebKit/601.3.9 (KHTML, like Gecko) Version/9.0.2 Safari/601.3.9"
@@ -179,6 +179,12 @@ func TestMultiField(t *testing.T) {
 	assertEqual(t, len(rows), 2)
 	assertEqual(t, rows[0], []string{"301", "GET", "6"})
 	assertEqual(t, rows[1], []string{"200", "GET", "5"})
+
+	columns, rows = runCommand(t, DEFAULT_LOG_FORMAT, SAMPLE_LOGS, []string{"user"})
+	assertEqual(t, columns, []string{"user", "#reqs"})
+	assertEqual(t, len(rows), 2)
+	assertEqual(t, rows[0], []string{"", "9"})
+	assertEqual(t, rows[1], []string{"facundo", "2"})
 }
 
 func TestWhereFilter(t *testing.T) {

--- a/ngtop/fields.go
+++ b/ngtop/fields.go
@@ -73,6 +73,12 @@ var KNOWN_FIELDS = []LogField{
 		ColumnSpec:   "TEXT",
 	},
 	{
+		LogFormatVar: "remote_user",
+		CLINames:     []string{"user", "username", "remote_user", "remoteuser"},
+		ColumnName:   "user",
+		ColumnSpec:   "TEXT",
+	},
+	{
 		LogFormatVar: "status",
 		CLINames:     []string{"status"},
 		ColumnName:   "status",


### PR DESCRIPTION
This adds remote_user (which is already part of nginx's default format) to the known fields specs.

Fixes #25